### PR TITLE
Use JsonSerializer that has been configured for parameter deserialization

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/HubRequestParser.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/HubRequestParser.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
             request.Method = deserializedData.Method;
             request.Id = deserializedData.Id;
             request.State = GetState(deserializedData);
-            request.ParameterValues = (deserializedData.Args != null) ? deserializedData.Args.Select(value => new JRawValue(value)).ToArray() : _emptyArgs;
+            request.ParameterValues = (deserializedData.Args != null) ? deserializedData.Args.Select(value => new JRawValue(value, serializer)).ToArray() : _emptyArgs;
 
             return request;
         }

--- a/src/Microsoft.AspNet.SignalR.Core/Json/JRawValue.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Json/JRawValue.cs
@@ -13,10 +13,12 @@ namespace Microsoft.AspNet.SignalR.Json
     internal class JRawValue : IJsonValue
     {
         private readonly string _value;
+        private readonly JsonSerializer _serializer;
 
-        public JRawValue(JRaw value)
+        public JRawValue(JRaw value, JsonSerializer serializer)
         {
             _value = value.ToString();
+            _serializer = serializer;
         }
 
         public object ConvertTo(Type type)
@@ -24,8 +26,7 @@ namespace Microsoft.AspNet.SignalR.Json
             // A non generic implementation of ToObject<T> on JToken
             using (var jsonReader = new StringReader(_value))
             {
-                var serializer = JsonUtility.CreateDefaultSerializer();
-                return serializer.Deserialize(jsonReader, type);
+                return _serializer.Deserialize(jsonReader, type);
             }
         }
 


### PR DESCRIPTION
The parameter deserialization in SignalR used a hard-coded JsonSerializer which meant it could not be overridden. This change uses the registered JsonSerializer to deserialize the parameters of a hub method call.

This allows parameters in SignalR hub methods to be defined as Interfaces and/or Abstract classes when the default JsonSerializer is configured to embed the types in the JSON payload (using JsonSerializerSettings.TypeNameHandling).

This is similar to #3304